### PR TITLE
Serialization tests for Job class

### DIFF
--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -55,6 +55,11 @@ abstract class Job implements \JsonSerializable
         $this->timeLimit = null;
     }
 
+    public function getTimeLimit()
+    {
+        return $this->timeLimit;
+    }
+
     public function getState()
     {
         return (array) json_decode($this->getResult()->getData());

--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -52,7 +52,7 @@ abstract class Job implements \JsonSerializable
 
     public function unsetTimeLimit()
     {
-        unset($this->timeLimit);
+        $this->timeLimit = null;
     }
 
     public function getState()
@@ -84,27 +84,23 @@ abstract class Job implements \JsonSerializable
 
     public function jsonSerialize()
     {
-        return (object) ['timeLimit' => $this->timeLimit, 'result' => $this->getResult()];
+        return (object) [
+            'timeLimit' => $this->timeLimit,
+            'result' => $this->getResult()->jsonSerialize()
+        ];
     }
 
-    public static function hydrate($json)
-    {
+    /**
+     * Hydrate an object from the json created by jsonSerialize().
+     * You will want to override this method when implementing specific jobs.
+     * You can use this function for the initial JSON decoding by calling
+     * parent::hydrate() in your implementation.
+     *
+     * @param string $json
+     *   JSON string used to hydrate a new instance of the class.
+     */
+    public static function hydrate($json) {
         $data = json_decode($json);
-
-        $reflector = new \ReflectionClass(self::class);
-        $object = $reflector->newInstanceWithoutConstructor();
-
-        $reflector = new \ReflectionClass($object);
-
-        $p = $reflector->getProperty('timeLimit');
-        $p->setAccessible(true);
-        $p->setValue($object, $data->timeLimit);
-
-        $class = $reflector->getParentClass();
-        $p = $class->getProperty('result');
-        $p->setAccessible(true);
-        $p->setValue($object, Result::hydrate(json_encode($data->result)));
-
-        return $object;
+        return $data;
     }
 }

--- a/src/Job/Method.php
+++ b/src/Job/Method.php
@@ -3,6 +3,8 @@
 
 namespace Procrastinator\Job;
 
+use Procrastinator\Result;
+
 class Method extends Job
 {
     private $object;
@@ -18,5 +20,25 @@ class Method extends Job
     protected function runIt()
     {
         return call_user_func([$this->object, $this->methodName]);
+    }
+
+    public static function hydrate($json): Method
+    {
+        $data = parent::hydrate($json);
+
+        $reflector = new \ReflectionClass(self::class);
+        $object = $reflector->newInstanceWithoutConstructor();
+
+        $reflector = new \ReflectionClass($object);
+
+        $p = $reflector->getParentClass()->getProperty('timeLimit');
+        $p->setAccessible(true);
+        $p->setValue($object, $data->timeLimit);
+
+        $p = $reflector->getParentClass()->getProperty('result');
+        $p->setAccessible(true);
+        $p->setValue($object, Result::hydrate(json_encode($data->result)));
+
+        return $object;
     }
 }


### PR DESCRIPTION
These tests demonstrate that serialization and hydration are working for the Job and Result classes. They also bring procrastinator's test coverage up to 100%. 

Note that the `unsetTimeLimit` method now sets `$timeLimit` to `null` rather than completely unsetting.