### PR TITLE
Improve state property handling, include timeLimit

### DIFF
--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -48,11 +48,12 @@ abstract class Job implements \JsonSerializable
     public function setTimeLimit(int $seconds)
     {
         $this->timeLimit = $seconds;
+        $this->setStateProperty('timeLimit', $this->timeLimit);
     }
 
     public function unsetTimeLimit()
     {
-        $this->timeLimit = null;
+        $this->setTimeLimit(null);
     }
 
     public function getTimeLimit()
@@ -65,9 +66,16 @@ abstract class Job implements \JsonSerializable
         return (array) json_decode($this->getResult()->getData());
     }
 
-    public function getStateProperty($property)
+    public function getStateProperty(string $property, $default = null)
     {
-        return $this->getState()[$property];
+        $state = $this->getState();
+        if (array_key_exists($property, $state)) {
+            return $state[$property];
+        } elseif (isset($default)) {
+            return $default;
+        } else {
+            throw new \Exception("The state property '$property' does not exist.");
+        }
     }
 
     public function getResult(): Result

--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -75,7 +75,7 @@ abstract class Job implements \JsonSerializable
         } elseif (isset($default)) {
             return $default;
         } else {
-            throw new \Exception("The state property '$property' does not exist.");
+            return false;
         }
     }
 

--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -48,13 +48,11 @@ abstract class Job implements \JsonSerializable
     public function setTimeLimit(int $seconds)
     {
         $this->timeLimit = $seconds;
-        $this->setStateProperty('timeLimit', $this->timeLimit);
     }
 
     public function unsetTimeLimit()
     {
         $this->timeLimit = null;
-        $this->setStateProperty('timeLimit', $this->timeLimit);
     }
 
     public function getTimeLimit()

--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -53,7 +53,8 @@ abstract class Job implements \JsonSerializable
 
     public function unsetTimeLimit()
     {
-        $this->setTimeLimit(null);
+        $this->timeLimit = null;
+        $this->setStateProperty('timeLimit', $this->timeLimit);
     }
 
     public function getTimeLimit()

--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -113,7 +113,8 @@ abstract class Job implements \JsonSerializable
      * @param string $json
      *   JSON string used to hydrate a new instance of the class.
      */
-    public static function hydrate($json) {
+    public static function hydrate($json)
+    {
         $data = json_decode($json);
         return $data;
     }


### PR DESCRIPTION
Makes the following improvements to state handling:

1. Allows us to pass a default value to `getStateProperty()` (kind of like drupal's `variable_get()`) 
2. Throws an exception if we try to get a non-existent state property without passing a default
3. Ensures that `Job::timeLimit` is always synced to a state property 