### PR TITLE
Throw exception if invalid JSON in hydrate

### DIFF
--- a/src/HydratableTrait.php
+++ b/src/HydratableTrait.php
@@ -8,6 +8,10 @@ trait HydratableTrait
     {
         $data = (array) json_decode($json);
 
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Exception(json_last_error_msg());
+        }
+
         $class = new \ReflectionClass(static::class);
 
         if (!$instance) {


### PR DESCRIPTION
`hydrate()` fails silently if passed invalid JSON. This throws an exception if JSON does not validate.