### PR TITLE
Don't default to PHP_MAX_INT for Job time limit

### DIFF
--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -14,7 +14,15 @@ abstract class Job implements \JsonSerializable
     use JsonSerializeTrait;
 
     private ?\Procrastinator\Result $result = null;
-    private int $timeLimit = PHP_INT_MAX;
+
+    /**
+     * Time limit in seconds.
+     *
+     * Defaults to three days.
+     *
+     * @var int
+     */
+    private int $timeLimit = 259200;
 
     abstract protected function runIt();
 
@@ -76,7 +84,7 @@ abstract class Job implements \JsonSerializable
         $this->setState($state);
     }
 
-    public function getTimeLimit()
+    public function getTimeLimit(): int
     {
         return $this->timeLimit;
     }


### PR DESCRIPTION
It turns out that if you don't call `Job->setTimeLimit()` and then try to do math with the result of `Job->getTimeLimit()`, you'll end up with a float.

That's because PHP_MAX_INT + any integer = math error.

This PR changes the default value of `Job::$timeLimit` to three days.