### PR TITLE
Add "waiting" result status

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -8,18 +8,19 @@ class Result implements HydratableInterface
 {
     use HydratableTrait;
 
+    public const WAITING = 'waiting';
     public const STOPPED = 'stopped';
     public const IN_PROGRESS = 'in_progress';
     public const ERROR = 'error';
     public const DONE = 'done';
 
-    private $status = self::STOPPED;
+    private $status = self::WAITING;
     private string $data = "";
     private string $error = "";
 
     public function setStatus($status)
     {
-        $statuss = [self::STOPPED, self::IN_PROGRESS, self::ERROR, self::DONE];
+        $statuss = [self::WAITING, self::STOPPED, self::IN_PROGRESS, self::ERROR, self::DONE];
         if (in_array($status, $statuss)) {
             $this->status = $status;
         } else {


### PR DESCRIPTION
In practice in DKAN, we have a "waiting" status that is distinct from "stopped." When a `Result` object does not exist, the status is reported as "waiting" but once a `Result` has been instantiated, there is no way to represent the same job as waiting to start. This adds a "waiting" status.

This should probably be a new major release, it has the potential to break backwards compatibility as the default value for status is now "waiting".