### PR TITLE
Support PHP 8.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[composer.{json,lock}]
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Exclude build/test files from archive
+/.circleci        export-ignore
+/test             export-ignore
+/.editorconfig    export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/docs             export-ignore
+/Doxyfile         export-ignore
+/doxygen.tag.xml  export-ignore
+/DoxygenLayout.xml export-ignore
+/phpcs.xml        export-ignore
+/phpunit.xml      export-ignore
+/rector.php       export-ignore
+
+# Configure diff output for .php and .phar files.
+*.php diff=php

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /vendor/
-.*
+.DS_Store
+.ddev
+.idea
+.phpunit.result.cache
 composer.lock
 html
 !.circleci

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,13 @@
     "require": {
         "php": ">7.3 <8.3",
         "ext-json": "*",
-        "getdkan/contracts": "^1.0.0"
+        "getdkan/contracts": "^1.1.2"
     },
     "require-dev": {
         "phpunit/phpunit": ">8.5.14 <10.0.0",
-        "rector/rector": "^0.15.17",
-        "squizlabs/php_codesniffer": "^3.7"
+        "rector/rector": "^0.16",
+        "squizlabs/php_codesniffer": "^3.7",
+        "symfony/phpunit-bridge": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,19 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" verbose="false">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         colors="true">
     <coverage processUncoveredFiles="true">
         <include>
-            <directory suffix=".php">src</directory>
+            <directory>src</directory>
         </include>
     </coverage>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
+    <php>
+        <!-- Don't fail for external dependencies. -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
+    </php>
     <testsuites>
         <testsuite name="all">
             <directory>test</directory>

--- a/rector.php
+++ b/rector.php
@@ -3,13 +3,14 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
-use Rector\Set\ValueObject\SetList;
+use Rector\Core\ValueObject\PhpVersion;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
-use Rector\Core\ValueObject\PhpVersion;
-use Rector\Set\ValueObject\LevelSetList;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
+use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -21,12 +22,6 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->phpVersion(PhpVersion::PHP_74);
 
     $rectorConfig->sets([
-        // Interestingly, LevelSetList::UP_TO_PHP_82 does not preserve PHP 7.4,
-        // so we have to specify all the PHP versions leading up to it if we
-        // want to keep 7.4 idioms.
-        SetList::PHP_74,
-        SetList::PHP_80,
-        SetList::PHP_81,
         SetList::PHP_82,
         // Please no dead code or unneeded variables.
         SetList::DEAD_CODE,
@@ -42,6 +37,8 @@ return static function (RectorConfig $rectorConfig): void {
         RemoveUselessParamTagRector::class,
         RemoveUselessReturnTagRector::class,
         RemoveUselessVarTagRector::class,
+        ArrayShapeFromConstantArrayReturnRector::class,
+        AddMethodCallBasedStrictParamTypeRector::class,
     ]);
 
     $rectorConfig->importNames();

--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -114,6 +114,9 @@ abstract class Job implements \JsonSerializable
         return $this->result;
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/src/Result.php
+++ b/src/Result.php
@@ -53,6 +53,9 @@ class Result implements HydratableInterface
         return $this->error;
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {


### PR DESCRIPTION
- Adds support files like `.gitattributes`
- Explicitly requires other getdkan library versions which are compatible with PHP 8.2.
- Adds symfon/phpunit-bridge so we fail on deprecations.